### PR TITLE
The _GNU_SOURCE feature test macro must be defined

### DIFF
--- a/test/cmp_max_used_bits/test_cmp_max_used_bits_list.c
+++ b/test/cmp_max_used_bits/test_cmp_max_used_bits_list.c
@@ -16,21 +16,25 @@
  * @brief max_used_bits list tests
  */
 
+#if !defined(__sparc__) && !defined(_WIN32) && !defined(_WIN64)
+#  define _GNU_SOURCE
+#  include <dlfcn.h>
+#endif
 
 #include <string.h>
-#include <dlfcn.h>
 
 #include <unity.h>
 
 #include <cmp_max_used_bits_list.h>
 
+#if !defined(__sparc__) && !defined(_WIN32) && !defined(_WIN64)
 /* if set the mock malloc will fail (return NULL) */
 static int malloc_fail;
 
 
 /*
  * mock of the malloc function; can controlled with the global malloc_fail variable
- * see:https://jayconrod.com/posts/23/tutorial--function-interposition-in-linux
+ * see: https://jayconrod.com/posts/23/tutorial--function-interposition-in-linux
  */
 
 void* malloc(size_t size)
@@ -45,10 +49,9 @@ void* malloc(size_t size)
 		/* The cast removes a gcc warning https://stackoverflow.com/a/31528674 */
 		TEST_ASSERT_NOT_NULL(real_malloc);
 	}
-
-	fprintf(stderr, "malloc(%zu)\n", size);
 	return real_malloc(size);
 }
+#endif
 
 
 /**
@@ -60,31 +63,31 @@ void* malloc(size_t size)
 
 void test_cmp_max_used_bits_list(void)
 {
-	struct cmp_max_used_bits i_17, i_21, i_22, i_23, i_255, i_0;
-	struct cmp_max_used_bits *p;
+	struct cmp_max_used_bits i_32, i_34, i_35, i_36, i_255, i_0;
+	const struct cmp_max_used_bits *p;
 	int return_val;
 
 	/* set up max_used_bits item */
-	memset(&i_17, 17, sizeof(struct cmp_max_used_bits));
-	i_17.version = 17;
-	memset(&i_21, 21, sizeof(struct cmp_max_used_bits));
-	i_21.version = 21;
-	memset(&i_22, 22, sizeof(struct cmp_max_used_bits));
-	i_22.version = 22;
-	memset(&i_23, 23, sizeof(struct cmp_max_used_bits));
-	i_23.version = 23;
+	memset(&i_32, 32, sizeof(struct cmp_max_used_bits));
+	i_32.version = 32;
+	memset(&i_34, 34, sizeof(struct cmp_max_used_bits));
+	i_34.version = 34;
+	memset(&i_35, 35, sizeof(struct cmp_max_used_bits));
+	i_35.version = 35;
+	memset(&i_36, 36, sizeof(struct cmp_max_used_bits));
+	i_36.version = 36;
 	memset(&i_255, 0xFF, sizeof(struct cmp_max_used_bits));
 	i_255.version = 255;
 	memset(&i_0, 0, sizeof(struct cmp_max_used_bits));
 	i_0.version = 0;
 
-	return_val = cmp_max_used_bits_list_add(&i_17);
+	return_val = cmp_max_used_bits_list_add(&i_32);
 	TEST_ASSERT_EQUAL_INT(return_val, 0);
-	return_val = cmp_max_used_bits_list_add(&i_21);
+	return_val = cmp_max_used_bits_list_add(&i_34);
 	TEST_ASSERT_EQUAL_INT(return_val, 0);
-	return_val = cmp_max_used_bits_list_add(&i_22);
+	return_val = cmp_max_used_bits_list_add(&i_35);
 	TEST_ASSERT_EQUAL_INT(return_val, 0);
-	return_val = cmp_max_used_bits_list_add(&i_23);
+	return_val = cmp_max_used_bits_list_add(&i_36);
 	TEST_ASSERT_EQUAL_INT(return_val, 0);
 	return_val = cmp_max_used_bits_list_add(&i_255);
 	TEST_ASSERT_EQUAL_INT(return_val, 0);
@@ -94,29 +97,29 @@ void test_cmp_max_used_bits_list(void)
 	TEST_ASSERT_EQUAL_INT(return_val, -1);
 	return_val = cmp_max_used_bits_list_add(&i_0);
 	TEST_ASSERT_EQUAL_INT(return_val, -1);
-	i_0.version = 16;
+	i_0.version = CMP_MAX_USED_BITS_RESERVED_VERSIONS-1;
 	return_val = cmp_max_used_bits_list_add(&i_0);
 	TEST_ASSERT_EQUAL_INT(return_val, -1);
 
-	p = cmp_max_used_bits_list_get(17);
-	TEST_ASSERT_EQUAL_INT(p->version, 17);
-	TEST_ASSERT(!memcmp(p, &i_17, sizeof(struct cmp_max_used_bits)));
+	p = cmp_max_used_bits_list_get(32);
+	TEST_ASSERT_EQUAL_INT(p->version, 32);
+	TEST_ASSERT(!memcmp(p, &i_32, sizeof(struct cmp_max_used_bits)));
 
-	p = cmp_max_used_bits_list_get(23);
-	TEST_ASSERT_EQUAL_INT(p->version, 23);
-	TEST_ASSERT(!memcmp(p, &i_23, sizeof(struct cmp_max_used_bits)));
+	p = cmp_max_used_bits_list_get(36);
+	TEST_ASSERT_EQUAL_INT(p->version, 36);
+	TEST_ASSERT(!memcmp(p, &i_36, sizeof(struct cmp_max_used_bits)));
 
-	p = cmp_max_used_bits_list_get(22);
-	TEST_ASSERT_EQUAL_INT(p->version, 22);
-	TEST_ASSERT(!memcmp(p, &i_22, sizeof(struct cmp_max_used_bits)));
+	p = cmp_max_used_bits_list_get(35);
+	TEST_ASSERT_EQUAL_INT(p->version, 35);
+	TEST_ASSERT(!memcmp(p, &i_35, sizeof(struct cmp_max_used_bits)));
 
 	p = cmp_max_used_bits_list_get(255);
 	TEST_ASSERT_EQUAL_INT(p->version, 255);
 	TEST_ASSERT(!memcmp(p, &i_255, sizeof(struct cmp_max_used_bits)));
 
-	p = cmp_max_used_bits_list_get(21);
-	TEST_ASSERT_EQUAL_INT(p->version, 21);
-	TEST_ASSERT(!memcmp(p, &i_21, sizeof(struct cmp_max_used_bits)));
+	p = cmp_max_used_bits_list_get(34);
+	TEST_ASSERT_EQUAL_INT(p->version, 34);
+	TEST_ASSERT(!memcmp(p, &i_34, sizeof(struct cmp_max_used_bits)));
 
 	p = cmp_max_used_bits_list_get(0);
 	TEST_ASSERT_EQUAL_INT(p->version, 0);
@@ -135,30 +138,30 @@ void test_cmp_max_used_bits_list(void)
 
 
 	/* overwrite a list item */
-	memset(&i_22, 0x42, sizeof(struct cmp_max_used_bits));
-	i_22.version = 22;
-	return_val = cmp_max_used_bits_list_add(&i_22);
+	memset(&i_35, 0x42, sizeof(struct cmp_max_used_bits));
+	i_35.version = 35;
+	return_val = cmp_max_used_bits_list_add(&i_35);
 	TEST_ASSERT_EQUAL_INT(return_val, 1);
-	p = cmp_max_used_bits_list_get(22);
-	TEST_ASSERT_EQUAL_INT(p->version, 22);
-	TEST_ASSERT(!memcmp(p, &i_22, sizeof(struct cmp_max_used_bits)));
+	p = cmp_max_used_bits_list_get(35);
+	TEST_ASSERT_EQUAL_INT(p->version, 35);
+	TEST_ASSERT(!memcmp(p, &i_35, sizeof(struct cmp_max_used_bits)));
 
 	/* delete item */
-	cmp_max_used_bits_list_delet(22);
-	p = cmp_max_used_bits_list_get(22);
+	cmp_max_used_bits_list_delet(35);
+	p = cmp_max_used_bits_list_get(35);
 	TEST_ASSERT_NULL(p);
 
-	cmp_max_used_bits_list_delet(21);
-	p = cmp_max_used_bits_list_get(21);
+	cmp_max_used_bits_list_delet(34);
+	p = cmp_max_used_bits_list_get(34);
 	TEST_ASSERT_NULL(p);
 
 	/* empty item */
 	cmp_max_used_bits_list_empty();
-	p = cmp_max_used_bits_list_get(23);
+	p = cmp_max_used_bits_list_get(36);
 	TEST_ASSERT_NULL(p);
 
 	cmp_max_used_bits_list_empty();
-	p = cmp_max_used_bits_list_get(21);
+	p = cmp_max_used_bits_list_get(34);
 	TEST_ASSERT_NULL(p);
 
 	p = cmp_max_used_bits_list_get(0);
@@ -169,18 +172,20 @@ void test_cmp_max_used_bits_list(void)
 	TEST_ASSERT_EQUAL_INT(p->version, 1);
 	TEST_ASSERT(!memcmp(p, &MAX_USED_BITS_V1, sizeof(struct cmp_max_used_bits)));
 
-	return_val = cmp_max_used_bits_list_add(&i_23);
+	return_val = cmp_max_used_bits_list_add(&i_36);
 	TEST_ASSERT_EQUAL_INT(return_val, 0);
 
-	p = cmp_max_used_bits_list_get(23);
-	TEST_ASSERT_EQUAL_INT(p->version, 23);
-	TEST_ASSERT(!memcmp(p, &i_23, sizeof(struct cmp_max_used_bits)));
+	p = cmp_max_used_bits_list_get(36);
+	TEST_ASSERT_EQUAL_INT(p->version, 36);
+	TEST_ASSERT(!memcmp(p, &i_36, sizeof(struct cmp_max_used_bits)));
 
 	cmp_max_used_bits_list_empty();
 
 	/* error case */
+#if !defined(__sparc__) && !defined(_WIN32) && !defined(_WIN64)
 	malloc_fail = 1;
-	return_val = cmp_max_used_bits_list_add(&i_23);
+	return_val = cmp_max_used_bits_list_add(&i_36);
 	TEST_ASSERT_EQUAL_INT(return_val, -1);
 	malloc_fail = 0;
+#endif
 }

--- a/test/cmp_max_used_bits/test_cmp_max_used_bits_list.c
+++ b/test/cmp_max_used_bits/test_cmp_max_used_bits_list.c
@@ -63,31 +63,31 @@ void* malloc(size_t size)
 
 void test_cmp_max_used_bits_list(void)
 {
-	struct cmp_max_used_bits i_32, i_34, i_35, i_36, i_255, i_0;
-	const struct cmp_max_used_bits *p;
+	struct cmp_max_used_bits i_17, i_21, i_22, i_23, i_255, i_0;
+	struct cmp_max_used_bits *p;
 	int return_val;
 
 	/* set up max_used_bits item */
-	memset(&i_32, 32, sizeof(struct cmp_max_used_bits));
-	i_32.version = 32;
-	memset(&i_34, 34, sizeof(struct cmp_max_used_bits));
-	i_34.version = 34;
-	memset(&i_35, 35, sizeof(struct cmp_max_used_bits));
-	i_35.version = 35;
-	memset(&i_36, 36, sizeof(struct cmp_max_used_bits));
-	i_36.version = 36;
+	memset(&i_17, 17, sizeof(struct cmp_max_used_bits));
+	i_17.version = 17;
+	memset(&i_21, 21, sizeof(struct cmp_max_used_bits));
+	i_21.version = 21;
+	memset(&i_22, 22, sizeof(struct cmp_max_used_bits));
+	i_22.version = 22;
+	memset(&i_23, 23, sizeof(struct cmp_max_used_bits));
+	i_23.version = 23;
 	memset(&i_255, 0xFF, sizeof(struct cmp_max_used_bits));
 	i_255.version = 255;
 	memset(&i_0, 0, sizeof(struct cmp_max_used_bits));
 	i_0.version = 0;
 
-	return_val = cmp_max_used_bits_list_add(&i_32);
+	return_val = cmp_max_used_bits_list_add(&i_17);
 	TEST_ASSERT_EQUAL_INT(return_val, 0);
-	return_val = cmp_max_used_bits_list_add(&i_34);
+	return_val = cmp_max_used_bits_list_add(&i_21);
 	TEST_ASSERT_EQUAL_INT(return_val, 0);
-	return_val = cmp_max_used_bits_list_add(&i_35);
+	return_val = cmp_max_used_bits_list_add(&i_22);
 	TEST_ASSERT_EQUAL_INT(return_val, 0);
-	return_val = cmp_max_used_bits_list_add(&i_36);
+	return_val = cmp_max_used_bits_list_add(&i_23);
 	TEST_ASSERT_EQUAL_INT(return_val, 0);
 	return_val = cmp_max_used_bits_list_add(&i_255);
 	TEST_ASSERT_EQUAL_INT(return_val, 0);
@@ -97,29 +97,29 @@ void test_cmp_max_used_bits_list(void)
 	TEST_ASSERT_EQUAL_INT(return_val, -1);
 	return_val = cmp_max_used_bits_list_add(&i_0);
 	TEST_ASSERT_EQUAL_INT(return_val, -1);
-	i_0.version = CMP_MAX_USED_BITS_RESERVED_VERSIONS-1;
+	i_0.version = 16;
 	return_val = cmp_max_used_bits_list_add(&i_0);
 	TEST_ASSERT_EQUAL_INT(return_val, -1);
 
-	p = cmp_max_used_bits_list_get(32);
-	TEST_ASSERT_EQUAL_INT(p->version, 32);
-	TEST_ASSERT(!memcmp(p, &i_32, sizeof(struct cmp_max_used_bits)));
+	p = cmp_max_used_bits_list_get(17);
+	TEST_ASSERT_EQUAL_INT(p->version, 17);
+	TEST_ASSERT(!memcmp(p, &i_17, sizeof(struct cmp_max_used_bits)));
 
-	p = cmp_max_used_bits_list_get(36);
-	TEST_ASSERT_EQUAL_INT(p->version, 36);
-	TEST_ASSERT(!memcmp(p, &i_36, sizeof(struct cmp_max_used_bits)));
+	p = cmp_max_used_bits_list_get(23);
+	TEST_ASSERT_EQUAL_INT(p->version, 23);
+	TEST_ASSERT(!memcmp(p, &i_23, sizeof(struct cmp_max_used_bits)));
 
-	p = cmp_max_used_bits_list_get(35);
-	TEST_ASSERT_EQUAL_INT(p->version, 35);
-	TEST_ASSERT(!memcmp(p, &i_35, sizeof(struct cmp_max_used_bits)));
+	p = cmp_max_used_bits_list_get(22);
+	TEST_ASSERT_EQUAL_INT(p->version, 22);
+	TEST_ASSERT(!memcmp(p, &i_22, sizeof(struct cmp_max_used_bits)));
 
 	p = cmp_max_used_bits_list_get(255);
 	TEST_ASSERT_EQUAL_INT(p->version, 255);
 	TEST_ASSERT(!memcmp(p, &i_255, sizeof(struct cmp_max_used_bits)));
 
-	p = cmp_max_used_bits_list_get(34);
-	TEST_ASSERT_EQUAL_INT(p->version, 34);
-	TEST_ASSERT(!memcmp(p, &i_34, sizeof(struct cmp_max_used_bits)));
+	p = cmp_max_used_bits_list_get(21);
+	TEST_ASSERT_EQUAL_INT(p->version, 21);
+	TEST_ASSERT(!memcmp(p, &i_21, sizeof(struct cmp_max_used_bits)));
 
 	p = cmp_max_used_bits_list_get(0);
 	TEST_ASSERT_EQUAL_INT(p->version, 0);
@@ -138,30 +138,30 @@ void test_cmp_max_used_bits_list(void)
 
 
 	/* overwrite a list item */
-	memset(&i_35, 0x42, sizeof(struct cmp_max_used_bits));
-	i_35.version = 35;
-	return_val = cmp_max_used_bits_list_add(&i_35);
+	memset(&i_22, 0x42, sizeof(struct cmp_max_used_bits));
+	i_22.version = 22;
+	return_val = cmp_max_used_bits_list_add(&i_22);
 	TEST_ASSERT_EQUAL_INT(return_val, 1);
-	p = cmp_max_used_bits_list_get(35);
-	TEST_ASSERT_EQUAL_INT(p->version, 35);
-	TEST_ASSERT(!memcmp(p, &i_35, sizeof(struct cmp_max_used_bits)));
+	p = cmp_max_used_bits_list_get(22);
+	TEST_ASSERT_EQUAL_INT(p->version, 22);
+	TEST_ASSERT(!memcmp(p, &i_22, sizeof(struct cmp_max_used_bits)));
 
 	/* delete item */
-	cmp_max_used_bits_list_delet(35);
-	p = cmp_max_used_bits_list_get(35);
+	cmp_max_used_bits_list_delet(22);
+	p = cmp_max_used_bits_list_get(22);
 	TEST_ASSERT_NULL(p);
 
-	cmp_max_used_bits_list_delet(34);
-	p = cmp_max_used_bits_list_get(34);
+	cmp_max_used_bits_list_delet(21);
+	p = cmp_max_used_bits_list_get(21);
 	TEST_ASSERT_NULL(p);
 
 	/* empty item */
 	cmp_max_used_bits_list_empty();
-	p = cmp_max_used_bits_list_get(36);
+	p = cmp_max_used_bits_list_get(23);
 	TEST_ASSERT_NULL(p);
 
 	cmp_max_used_bits_list_empty();
-	p = cmp_max_used_bits_list_get(34);
+	p = cmp_max_used_bits_list_get(21);
 	TEST_ASSERT_NULL(p);
 
 	p = cmp_max_used_bits_list_get(0);
@@ -172,20 +172,18 @@ void test_cmp_max_used_bits_list(void)
 	TEST_ASSERT_EQUAL_INT(p->version, 1);
 	TEST_ASSERT(!memcmp(p, &MAX_USED_BITS_V1, sizeof(struct cmp_max_used_bits)));
 
-	return_val = cmp_max_used_bits_list_add(&i_36);
+	return_val = cmp_max_used_bits_list_add(&i_23);
 	TEST_ASSERT_EQUAL_INT(return_val, 0);
 
-	p = cmp_max_used_bits_list_get(36);
-	TEST_ASSERT_EQUAL_INT(p->version, 36);
-	TEST_ASSERT(!memcmp(p, &i_36, sizeof(struct cmp_max_used_bits)));
+	p = cmp_max_used_bits_list_get(23);
+	TEST_ASSERT_EQUAL_INT(p->version, 23);
+	TEST_ASSERT(!memcmp(p, &i_23, sizeof(struct cmp_max_used_bits)));
 
 	cmp_max_used_bits_list_empty();
 
 	/* error case */
-#if !defined(__sparc__) && !defined(_WIN32) && !defined(_WIN64)
 	malloc_fail = 1;
-	return_val = cmp_max_used_bits_list_add(&i_36);
+	return_val = cmp_max_used_bits_list_add(&i_23);
 	TEST_ASSERT_EQUAL_INT(return_val, -1);
 	malloc_fail = 0;
-#endif
 }


### PR DESCRIPTION
in order to obtain the definitions of RTLD_DEFAULT and RTLD_NEXT from <dlfcn.h>.